### PR TITLE
Added more properties for the image search, suggest property values where prossible

### DIFF
--- a/src/derpi_tag_autocomplete.js
+++ b/src/derpi_tag_autocomplete.js
@@ -10,14 +10,20 @@
     const scrollEvent = new Event('scroll'), API_TIMEOUT = 200;
     let fetchfunc, cleanQuery, apifetchfunc;
 
-    // 0 -> text
-    // 1 -> range
+    const literal_property = 0;
+    const ranged_property = 1;
+
     const special_searches = [
-        ["animated", 0], ["aspect_ratio", 1], ["comment_count", 1], ["created_at", 1], ["description", 0],
-        ["downvotes", 1], ["duration", 1], ["faved_by", 0], ["faves", 1], ["file_name", 0], ["first_seen_at", 1],
-        ["gallery_id", 0], ["height", 1], ["id", 1], ["mime_type", 0], ["orig_sha512_hash", 0], ["original_format", 0],
-        ["pixels", 1], ["score", 1], ["sha512_hash", 0], ["size", 1], ["source_count", 1], ["source_url", 0],
-        ["tag_count", 1], ["updated_at", 1], ["uploader", 0], ["upvotes", 1], ["width", 1], ["wilson_score", 1]
+        ["animated", literal_property], ["aspect_ratio", ranged_property], ["comment_count", ranged_property],
+        ["created_at", ranged_property], ["description", literal_property], ["downvotes", ranged_property],
+        ["duration", ranged_property], ["faved_by", literal_property], ["faves", ranged_property],
+        ["file_name", literal_property], ["first_seen_at", ranged_property], ["gallery_id", literal_property],
+        ["height", ranged_property], ["id", ranged_property], ["mime_type", literal_property],
+        ["orig_sha512_hash", literal_property], ["original_format", literal_property], ["pixels", ranged_property],
+        ["score", ranged_property], ["sha512_hash", literal_property], ["size", ranged_property],
+        ["source_count", ranged_property], ["source_url", literal_property], ["tag_count", ranged_property],
+        ["updated_at", ranged_property], ["uploader", literal_property], ["upvotes", ranged_property],
+        ["width", ranged_property], ["wilson_score", ranged_property],
     ], range_modifiers = [
         ".gt", ".lt", ".gte", ".lte"
     ];
@@ -102,7 +108,7 @@
                 if (Settings.preferences.special_searches) {
                     for (const [special, type] of special_searches) if (special.startsWith(curr)) {
                         specials.push({aliased_tag: null, name: special + ":", images: -1});
-                        if (type === 1) for (const modifier of range_modifiers) {
+                        if (type === ranged_property) for (const modifier of range_modifiers) {
                             specials.push({aliased_tag: null, name: `${special}${modifier}:`, images: -1});
                         }
                     }

--- a/src/derpi_tag_autocomplete.js
+++ b/src/derpi_tag_autocomplete.js
@@ -129,6 +129,11 @@
                             continue;
                         }
 
+                        // Only add the property without modifier if user haven't typed it yet.
+                        if (!hasStartedTypingModifier) {
+                            specials.push({aliased_tag: null, name: `${special}:${currValuePart}`, images: -1})
+                        }
+
                         if (type === ranged_property) {
                             for (const modifier of range_modifiers) {
                                 // Display all if modifier isn't typed yet or match the modifier to the one user have typed.
@@ -136,12 +141,7 @@
 
                                 specials.push({aliased_tag: null,name: `${special}${modifier}:${currValuePart}`,images: -1});
                             }
-
-                            // Do not display property without modifier, since there is no point.
-                            if (hasStartedTypingModifier) continue;
                         }
-
-                        specials.push({aliased_tag: null, name: `${special}:${currValuePart}`, images: -1});
                     }
                 }
             } else ++page;

--- a/src/derpi_tag_autocomplete.js
+++ b/src/derpi_tag_autocomplete.js
@@ -107,6 +107,12 @@
                 items = 0;
                 if (Settings.preferences.special_searches) {
                     for (const [special, type] of special_searches) if (special.startsWith(curr)) {
+                        if (Array.isArray(type)) {
+                            for (const value of type) if (`${special}:${value}`.startsWith(curr)) {
+                                specials.push({aliased_tag: null, name: `${special}:${value}`, images: -1});
+                            }
+                            continue;
+                        }
                         specials.push({aliased_tag: null, name: special + ":", images: -1});
                         if (type === ranged_property) for (const modifier of range_modifiers) {
                             specials.push({aliased_tag: null, name: `${special}${modifier}:`, images: -1});

--- a/src/derpi_tag_autocomplete.js
+++ b/src/derpi_tag_autocomplete.js
@@ -114,16 +114,20 @@
                 page = 1;
                 items = 0;
                 if (Settings.preferences.special_searches) {
-                    for (const [special, type] of special_searches) if (special.startsWith(curr)) {
+                    const currParts = curr.split(':');
+                    const currSpecialPart = currParts.shift();
+                    const currValuePart = currParts.join(':');
+
+                    for (const [special, type] of special_searches) if (special.startsWith(currSpecialPart)) {
                         if (Array.isArray(type)) {
-                            for (const value of type) if (`${special}:${value}`.startsWith(curr)) {
+                            for (const value of type) if (value.startsWith(currValuePart)) {
                                 specials.push({aliased_tag: null, name: `${special}:${value}`, images: -1});
                             }
                             continue;
                         }
-                        specials.push({aliased_tag: null, name: special + ":", images: -1});
+                        specials.push({aliased_tag: null, name: `${special}:${currValuePart}`, images: -1});
                         if (type === ranged_property) for (const modifier of range_modifiers) {
-                            specials.push({aliased_tag: null, name: `${special}${modifier}:`, images: -1});
+                            specials.push({aliased_tag: null, name: `${special}${modifier}:${currValuePart}`, images: -1});
                         }
                     }
                 }

--- a/src/derpi_tag_autocomplete.js
+++ b/src/derpi_tag_autocomplete.js
@@ -12,18 +12,26 @@
 
     const literal_property = 0;
     const ranged_property = 1;
+    const boolean_property = ['true', 'false'];
+    const my_namespace = ['comments', 'faves', 'uploads', 'upvotes', 'watched'];
 
     const special_searches = [
-        ["animated", literal_property], ["aspect_ratio", ranged_property], ["comment_count", ranged_property],
+        ["animated", boolean_property], ["aspect_ratio", ranged_property], ["body_type_tag_count", ranged_property],
+        ["character_tag_count", ranged_property], ["comment_count", ranged_property],
+        ["content_fanmade_tag_count", ranged_property], ["content_official_tag_count", ranged_property],
         ["created_at", ranged_property], ["description", literal_property], ["downvotes", ranged_property],
-        ["duration", ranged_property], ["faved_by", literal_property], ["faves", ranged_property],
-        ["file_name", literal_property], ["first_seen_at", ranged_property], ["gallery_id", literal_property],
-        ["height", ranged_property], ["id", ranged_property], ["mime_type", literal_property],
-        ["orig_sha512_hash", literal_property], ["original_format", literal_property], ["pixels", ranged_property],
+        ["duplicate_id", ranged_property], ["duration", ranged_property], ["faved_by", literal_property],
+        ["faves", ranged_property], ["file_name", literal_property], ["first_seen_at", ranged_property],
+        ["gallery_id", literal_property], ["height", ranged_property], ["id", ranged_property],
+        ["mime_type", literal_property], ["my", my_namespace], ["oc_tag_count", ranged_property],
+        ["orig_sha512_hash", literal_property], ["orig_size", ranged_property], ["original_format", literal_property],
+        ["pixels", ranged_property], ["processed", boolean_property], ["rating_tag_count", ranged_property],
         ["score", ranged_property], ["sha512_hash", literal_property], ["size", ranged_property],
-        ["source_count", ranged_property], ["source_url", literal_property], ["tag_count", ranged_property],
-        ["updated_at", ranged_property], ["uploader", literal_property], ["upvotes", ranged_property],
-        ["width", ranged_property], ["wilson_score", ranged_property],
+        ["source_count", ranged_property], ["source_url", literal_property], ["species_tag_count", ranged_property],
+        ["spoiler_tag_count", ranged_property], ["tag_count", ranged_property],
+        ["thumbnails_generated", boolean_property], ["updated_at", ranged_property], ["uploader", literal_property],
+        ['uploader_id', ranged_property], ["upvotes", ranged_property], ["width", ranged_property],
+        ["wilson_score", ranged_property],
     ], range_modifiers = [
         ".gt", ".lt", ".gte", ".lte"
     ];

--- a/src/derpi_tag_autocomplete.js
+++ b/src/derpi_tag_autocomplete.js
@@ -114,9 +114,12 @@
                 page = 1;
                 items = 0;
                 if (Settings.preferences.special_searches) {
-                    const currParts = curr.split(':');
-                    const currSpecialPart = currParts.shift();
+                    const /** @type {string[]} */ currParts = curr.split(':');
+                    const currSpecialWithModifier = currParts.shift().split('.');
+                    const currSpecialPart = currSpecialWithModifier.shift();
+                    const currModifierPart = currSpecialWithModifier.join('.');
                     const currValuePart = currParts.join(':');
+                    const hasStartedTypingModifier = currSpecialWithModifier.length > 0;
 
                     for (const [special, type] of special_searches) if (special.startsWith(currSpecialPart)) {
                         if (Array.isArray(type)) {
@@ -125,10 +128,20 @@
                             }
                             continue;
                         }
-                        specials.push({aliased_tag: null, name: `${special}:${currValuePart}`, images: -1});
-                        if (type === ranged_property) for (const modifier of range_modifiers) {
-                            specials.push({aliased_tag: null, name: `${special}${modifier}:${currValuePart}`, images: -1});
+
+                        if (type === ranged_property) {
+                            for (const modifier of range_modifiers) {
+                                // Display all if modifier isn't typed yet or match the modifier to the one user have typed.
+                                if (hasStartedTypingModifier && !modifier.startsWith(`.${currModifierPart}`)) continue;
+
+                                specials.push({aliased_tag: null,name: `${special}${modifier}:${currValuePart}`,images: -1});
+                            }
+
+                            // Do not display property without modifier, since there is no point.
+                            if (hasStartedTypingModifier) continue;
                         }
+
+                        specials.push({aliased_tag: null, name: `${special}:${currValuePart}`, images: -1});
                     }
                 }
             } else ++page;


### PR DESCRIPTION
- More properties, including the undocumented ones gathered right from the Philomena source code;
- Suggest values for special namespaces like `my:` or booleans like `animated:`;
  <img width="315" height="225" alt="image" src="https://github.com/user-attachments/assets/a4ae3959-3a27-463c-89e2-d400ed1abacd" />
- Property values matched as well (they weren't before);
  <img width="332" height="117" alt="image" src="https://github.com/user-attachments/assets/8c672fc9-5552-44ff-861c-97535325a4b9" />
- Ranged properties modifiers are not matched too (they weren't before as well);
  <img width="311" height="120" alt="image" src="https://github.com/user-attachments/assets/274a3439-226f-4943-a7f1-1b403ac4fc08" />
- Numeric or literal properties now retain their values and suggest modifiers with values prefilled;
  <img width="317" height="228" alt="image" src="https://github.com/user-attachments/assets/e1e8cabf-1c7e-42d7-80ea-08774627004e" />
